### PR TITLE
Changing destination port to match image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # volumes:
     #  - ./target/:/usr/local/tomcat/webapps/
     ports:
-    - 8080:80
+    - 8080:8080
     - 8443:443
     environment:
       TZ: ${TZ:-UTC}


### PR DESCRIPTION
This change lets you connect to the docker container per the instructions:  http://localhost:8080 from the docker host.
For some reason, the image on gitlab is now running the service on port 8080.    
I verified this by bringing up the image.  After being unable to connect via a web browser, I connected with "docker exec -t -i 6eb0910db4e0 /bin/sh" and netstat -n showed:
"tcp        0      0 0.0.0.0:8080            0.0.0.0:*               LISTEN"