### PR TITLE
updating troubleshooting syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ TO DO...
 
 ## Troubleshooting
 
-If you need to access the container in order to troubleshoot one or more errors, you should use the `docker exec -t -i _container name_ /bin/bash -l` command to connect to the container replacing **_container_name_** with the actual name of the container shown when you run `docker ps -a`.  
+If you need to access the container in order to troubleshoot one or more errors, you should use the `docker exec -t -i _container id_ /bin/ash` command to connect to the container replacing **_ _container id_ _** with the actual ID of the container shown in the first column when you run `docker ps -a`.  
 
 Once connected, error information can be found in the **/var/log/apache2/apitool_error_log** file.
 


### PR DESCRIPTION
1. Changed the command to get a shell.  /bin/bash doesn't exist in the new image, but /bin/ash does (so does /bin/sh).  They all get you to busybox.
2. changed the syntax to be container id instead of container name.  It was more specific and easier.  I mainly did it to fix the leading and trailing underlines in the _container id_ because they got lost in the syntax for bold ( **_ ).  I made the mistake of using _ecc99ad9c6f1_ as my container ID and I thought others might too.